### PR TITLE
Add nose to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 dsltools
 numpy
 appdirs
+nose


### PR DESCRIPTION
nose is also a requirement and parakeet cannot be installed through pip if nose is not previously installed
Fix issue #26 