### PR TITLE
docs: Fix a few typos

### DIFF
--- a/parakeet/builder/array_builder.py
+++ b/parakeet/builder/array_builder.py
@@ -163,7 +163,7 @@ class ArrayBuilder(ArithBuilder):
   def output_slice(self, output, axis, idx):
     """
     Create an expression which acts as an LHS output location 
-    for a slice throught the variable 'output' along the given axis
+    for a slice through the variable 'output' along the given axis
     """
     r = self.rank(output)
     if r > 1:

--- a/parakeet/openmp_backend/multicore_compiler.py
+++ b/parakeet/openmp_backend/multicore_compiler.py
@@ -75,7 +75,7 @@ class MulticoreCompiler(PyModuleCompiler):
     last_input_type = input_types[-1]
     body = ""
     if isinstance(last_input_type, TupleT):
-      # make a tupke out of the loop variables
+      # make a tuple out of the loop variables
       
       c_tuple_t = self.to_ctype(last_input_type)
       index_tuple = self.fresh_var(c_tuple_t, "index_tuple")

--- a/parakeet/transforms/scalar_replacement.py
+++ b/parakeet/transforms/scalar_replacement.py
@@ -110,7 +110,7 @@ class ScalarReplacement(LoopTransform):
         stmt.merge[loop_var.name] = (input_var, final_var)
       
       self.blocks.append(stmt)
-      # write out the results back to memeory 
+      # write out the results back to memory 
       for ( (array_name, index_expr), loop_var) in loop_scalars.iteritems():
         array_type = self.type_env[array_name]
         lhs = self.index(Var(array_name, type = array_type), index_expr, temp = False)


### PR DESCRIPTION
There are small typos in:
- parakeet/builder/array_builder.py
- parakeet/openmp_backend/multicore_compiler.py
- parakeet/transforms/scalar_replacement.py

Fixes:
- Should read `tuple` rather than `tupke`.
- Should read `memory` rather than `memeory`.
- Should read `through` rather than `throught`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md